### PR TITLE
libshvbroker: fix certificate chain loading

### DIFF
--- a/libshvbroker/src/appclioptions.cpp
+++ b/libshvbroker/src/appclioptions.cpp
@@ -25,9 +25,7 @@ AppCliOptions::AppCliOptions()
 	addOption("server.ssl.key").setType(cp::RpcValue::Type::String).setNames("--server-ssl-key")
 			.setComment("SSL key file").setDefaultValue("wss.key");
 	addOption("server.ssl.cert").setType(cp::RpcValue::Type::String).setNames("--server-ssl-cert")
-			.setComment("SSL certificate file").setDefaultValue("wss.crt");
-	addOption("server.ssl.intermediateCert").setType(cp::RpcValue::Type::String).setNames("--server-ssl-intermediate-cert")
-			.setComment("SSL intermediate certificate file").setDefaultValue("wss.intermediateCrt");
+			.setComment("List of SSL certificate files").setDefaultValue("wss.crt");
 	addOption("server.publicIP").setType(cp::RpcValue::Type::String).setNames("--pip", "--server-public-ip").setComment("Server public IP address");
 	addOption("sqlconfig.enabled").setType(cp::RpcValue::Type::Bool).setNames("--sql-config-enabled")
 			.setComment("SQL config enabled")

--- a/libshvbroker/src/appclioptions.h
+++ b/libshvbroker/src/appclioptions.h
@@ -27,8 +27,7 @@ public:
 	CLIOPTION_GETTER_SETTER2(int, "server.websocket.sslport", s, setS, erverWebsocketSslPort)
 #endif
 	CLIOPTION_GETTER_SETTER2(std::string, "server.ssl.key", s, setS, erverSslKeyFile)
-	CLIOPTION_GETTER_SETTER2(std::string, "server.ssl.cert", s, setS, erverSslCertFile)
-	CLIOPTION_GETTER_SETTER2(std::string, "server.ssl.intermediateCert", s, setS, erverSslIntermediateCertFile)
+	CLIOPTION_GETTER_SETTER2(std::string, "server.ssl.cert", s, setS, erverSslCertFiles)
 	CLIOPTION_GETTER_SETTER2(std::string, "server.publicIP", p, setP, ublicIP)
 
 	//CLIOPTION_GETTER_SETTER2(std::string, "etc.acl.fstab", f, setF, stabFile)


### PR DESCRIPTION
Pass all certificate files in single "ssl.certs" config option.
Load all certificates contained in a single certificate file.