### PR TITLE
Fix operator <. Because Severity use NecroLog::Level {Invalid = 0, Fa…

### DIFF
--- a/libshvcore/src/utils/shvalarm.cpp
+++ b/libshvcore/src/utils/shvalarm.cpp
@@ -34,7 +34,7 @@ const char* ShvAlarm::severityName() const
 
 bool ShvAlarm::operator<(const ShvAlarm &a) const
 {
-	if (m_severity < a.m_severity) return true;
+	if (m_severity > a.m_severity) return true;
 	if (m_severity == a.m_severity && m_level < a.m_level) return true;
 	return false;
 }


### PR DESCRIPTION
…tal, Error, Warning, Info, Message, Debug} and bigger severity has lower value.

@fvacek 