### PR TITLE
libshvchainpack/c/chainpack.c: do not use masked value assignment bool

### DIFF
--- a/libshvchainpack/c/cchainpack.c
+++ b/libshvchainpack/c/cchainpack.c
@@ -519,9 +519,11 @@ static void unpack_int(ccpcp_unpack_context* unpack_context, int64_t *pval)
 	unpack_uint(unpack_context, &num, &bitlen);
 	if(unpack_context->err_no == CCPCP_RC_OK) {
 		uint64_t sign_bit_mask = (uint64_t)1 << (bitlen - 1);
-		bool neg = num & sign_bit_mask;
 		snum = (int64_t)num;
-		if(neg) {
+
+		// Note: masked value assignment to bool variable would be undefined on some platforms.
+
+		if(num & sign_bit_mask) {
 			snum &= ~sign_bit_mask;
 			snum = -snum;
 		}


### PR DESCRIPTION
Masked value assignment to bool may result in undefined behaviour on some platforms (Cortex M7 on NuttX) and thus return incorrect integer value. This commit moves the negative check to if statement.