### PR TITLE
Fix compilation error with GCC 12.1

### DIFF
--- a/libshvcore/src/utils.cpp
+++ b/libshvcore/src/utils.cpp
@@ -2,6 +2,7 @@
 #include "log.h"
 #include "stringview.h"
 
+#include <cstring>
 #include <regex>
 #include <sstream>
 


### PR DESCRIPTION
`strerror` is in <cstring>, so we need to include that.