### PR TITLE
libshvbroker: Change case of sslport

### DIFF
--- a/libshvbroker/src/appclioptions.cpp
+++ b/libshvbroker/src/appclioptions.cpp
@@ -20,7 +20,7 @@ AppCliOptions::AppCliOptions()
 #ifdef WITH_SHV_WEBSOCKETS
 	addOption("server.websocket.port").setType(cp::RpcValue::Type::Int).setNames("--server-ws-port")
 			.setComment("Web socket server port, set this option to enable websocket server").setDefaultValue(3777);
-	addOption("server.websocket.sslport").setType(cp::RpcValue::Type::Int).setNames("--server-wss-port")
+	addOption("server.websocket.sslPort").setType(cp::RpcValue::Type::Int).setNames("--server-wss-port")
 			.setComment("Secure web socket server port, set this option to enable secure websocket server").setDefaultValue(3778);
 #endif
 	addOption("server.ssl.key").setType(cp::RpcValue::Type::String).setNames("--server-ssl-key")

--- a/libshvbroker/src/appclioptions.h
+++ b/libshvbroker/src/appclioptions.h
@@ -25,7 +25,7 @@ public:
 	CLIOPTION_GETTER_SETTER2(int, "server.discoveryPort", d, setD, iscoveryPort)
 #ifdef WITH_SHV_WEBSOCKETS
 	CLIOPTION_GETTER_SETTER2(int, "server.websocket.port", s, setS, erverWebsocketPort)
-	CLIOPTION_GETTER_SETTER2(int, "server.websocket.sslport", s, setS, erverWebsocketSslPort)
+	CLIOPTION_GETTER_SETTER2(int, "server.websocket.sslPort", s, setS, erverWebsocketSslPort)
 #endif
 	CLIOPTION_GETTER_SETTER2(std::string, "server.ssl.key", s, setS, erverSslKeyFile)
 	CLIOPTION_GETTER_SETTER2(std::string, "server.ssl.cert", s, setS, erverSslCertFiles)


### PR DESCRIPTION
The SSL port for the server is also "sslPort". This change makes the
config file more consistent.

If this is a major breaking change, feel free to reject it.