### PR TITLE
libshviotqt: Fix ClientConnection slot called after dtor

### DIFF
--- a/libshviotqt/src/rpc/clientconnection.cpp
+++ b/libshviotqt/src/rpc/clientconnection.cpp
@@ -49,6 +49,7 @@ ClientConnection::ClientConnection(QObject *parent)
 
 ClientConnection::~ClientConnection()
 {
+	disconnect(this, &SocketRpcConnection::socketConnectedChanged, this, &ClientConnection::onSocketConnectedChanged);
 	shvDebug() << __FUNCTION__;
 }
 


### PR DESCRIPTION
ClientConnection connects its slot to a signal of the base
SocketRpcConnection class. SocketRpcConnection is able to emit this
signal in its destructor. Because SocketRpcConnection is a base class of
ClientConnection, you no longer have an object of type ClientConnection,
when inside the SocketRpcConnection destructor. However, the signal is
connected to a slot of ClientConnection, so Qt obliges and calls the
ClientConnection slot. Such a call is invalid, because ClientConnection
no longer exists.

Solve this by disconnecting the connection in ClientConnection's destructor.
That way, the base class won't call any slots in the derived class.

Found by UBSAN.

This is how Qt tries to cast to ClientConnection
```
/usr/include/qt/QtCore/qobjectdefs_impl.h:418:94: runtime error: downcast of address 0x6150000e2200 which does not point to an object of type 'ClientConnection'
0x6150000e2200: note: object is of type 'shv::iotqt::rpc::SocketRpcConnection'
```
And here is the backtrace. Frame 21 is the destructor of
ClientConnection and frame 0 is the invalid call.
```
/home/vk/git/shvspy/3rdparty/libshv/libshviotqt/src/rpc/clientconnection.cpp:334:11: runtime error: member call on address 0x6150000e2200 which does not point to an object of type 'ClientConnection'
0x6150000e2200: note: object is of type 'shv::iotqt::rpc::SocketRpcConnection'
 00 00 00 00  30 6f 8f ee ae 7f 00 00  20 88 0e 00 80 60 00 00  d0 6f 8f ee ae 7f 00 00  01 00 00 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'shv::iotqt::rpc::SocketRpcConnection'
    0 0x7faeee5650ef in shv::iotqt::rpc::ClientConnection::onSocketConnectedChanged(bool) /home/vk/git/shvspy/3rdparty/libshv/libshviotqt/src/rpc/clientconnection.cpp:334
    1 0x7faeee58a5a9 in QtPrivate::FunctorCall<QtPrivate::IndexesList<0>, QtPrivate::List<bool>, void, void (shv::iotqt::rpc::ClientConnection::*)(bool)>::call(void (shv::iotqt::rpc::ClientConnection::*)(bool), shv::iotqt::rpc::ClientConnection*, void**) (/home/vk/git/shvspy/build/bin/../lib/libshviotqt.so.1+0x58a5a9)
    2 0x7faeee589019 in void QtPrivate::FunctionPointer<void (shv::iotqt::rpc::ClientConnection::*)(bool)>::call<QtPrivate::List<bool>, void>(void (shv::iotqt::rpc::ClientConnection::*)(bool), shv::iotqt::rpc::ClientConnection*, void**) (/home/vk/git/shvspy/build/bin/../lib/libshviotqt.so.1+0x589019)
    3 0x7faeee58455e in QtPrivate::QSlotObject<void (shv::iotqt::rpc::ClientConnection::*)(bool), QtPrivate::List<bool>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) /usr/include/qt/QtCore/qobjectdefs_impl.h:418
    4 0x7faeebabd620  (/usr/lib/libQt5Core.so.5+0x2bd620)
    5 0x7faeee7a346f in shv::iotqt::rpc::SocketRpcConnection::socketConnectedChanged(bool) /home/vk/git/shvspy/build/3rdparty/libshv/libshviotqt/moc_socketrpcconnection.cpp:195
    6 0x7faeee5a2ea3 in operator() /home/vk/git/shvspy/3rdparty/libshv/libshviotqt/src/rpc/socketrpcconnection.cpp:85
    7 0x7faeee5abf02 in call /usr/include/qt/QtCore/qobjectdefs_impl.h:146
    8 0x7faeee5ab76a in call<QtPrivate::List<>, void> /usr/include/qt/QtCore/qobjectdefs_impl.h:256
    9 0x7faeee5ab6bb in impl /usr/include/qt/QtCore/qobjectdefs_impl.h:443
    10 0x7faeebabd620  (/usr/lib/libQt5Core.so.5+0x2bd620)
    11 0x7faeee7ac308 in shv::iotqt::rpc::Socket::disconnected() /home/vk/git/shvspy/build/3rdparty/libshv/libshviotqt/moc_socket.cpp:240
    12 0x7faeee5f2eda in QtPrivate::FunctorCall<QtPrivate::IndexesList<>, QtPrivate::List<>, void, void (shv::iotqt::rpc::Socket::*)()>::call(void (shv::iotqt::rpc::Socket::*)(), shv::iotqt::rpc::Socket*, void**) /usr/include/qt/QtCore/qobjectdefs_impl.h:152
    13 0x7faeee5f29af in void QtPrivate::FunctionPointer<void (shv::iotqt::rpc::Socket::*)()>::call<QtPrivate::List<>, void>(void (shv::iotqt::rpc::Socket::*)(), shv::iotqt::rpc::Socket*, void**) /usr/include/qt/QtCore/qobjectdefs_impl.h:185
    14 0x7faeee5f13a8 in QtPrivate::QSlotObject<void (shv::iotqt::rpc::Socket::*)(), QtPrivate::List<>, void>::impl(int, QtPrivate::QSlotObjectBase*, QObject*, void**, bool*) /usr/include/qt/QtCore/qobjectdefs_impl.h:418
    15 0x7faeebabd620  (/usr/lib/libQt5Core.so.5+0x2bd620)
    16 0x7faef1929cee in QAbstractSocket::disconnectFromHost() (/usr/lib/libQt5Network.so.5+0xc4cee)
    17 0x7faeee5ecd73 in shv::iotqt::rpc::TcpSocket::abort() /home/vk/git/shvspy/3rdparty/libshv/libshviotqt/src/rpc/socket.cpp:57
    18 0x7faeee5a87c0 in shv::iotqt::rpc::SocketRpcConnection::abortSocket() /home/vk/git/shvspy/3rdparty/libshv/libshviotqt/src/rpc/socketrpcconnection.cpp:252
    19 0x7faeee5a045f in shv::iotqt::rpc::SocketRpcConnection::~SocketRpcConnection() /home/vk/git/shvspy/3rdparty/libshv/libshviotqt/src/rpc/socketrpcconnection.cpp:50
    20 0x7faeee552580 in shv::iotqt::rpc::ClientConnection::~ClientConnection() /home/vk/git/shvspy/3rdparty/libshv/libshviotqt/src/rpc/clientconnection.cpp:53
    21 0x7faeee55261d in shv::iotqt::rpc::ClientConnection::~ClientConnection() /home/vk/git/shvspy/3rdparty/libshv/libshviotqt/src/rpc/clientconnection.cpp:53
```