### PR TITLE
libshviotqt: RpcCall: delete after maybeResult slots

### DIFF
--- a/libshviotqt/src/rpc/rpcresponsecallback.cpp
+++ b/libshviotqt/src/rpc/rpcresponsecallback.cpp
@@ -1,5 +1,6 @@
 #include "rpcresponsecallback.h"
 #include "clientconnection.h"
+#include "rpc.h"
 
 #include <shv/chainpack/rpcmessage.h>
 #include <shv/coreqt/log.h>
@@ -128,8 +129,9 @@ RpcCall::RpcCall(ClientConnection *connection)
 			emit result(_result);
 		else
 			emit error(_error);
-		deleteLater();
 	});
+
+	connect(this, &RpcCall::maybeResult, this, &QObject::deleteLater, Qt::QueuedConnection);
 }
 
 RpcCall *RpcCall::createSubscriptionRequest(ClientConnection *connection, const QString &shv_path, const QString &method)


### PR DESCRIPTION
The problem with deleting directly inside the maybeResult slot (the
lambda), is that all queued connections to maybeResult get discarded.