### PR TITLE
Fix declaring a struct as class

### DIFF
--- a/libshviotqt/src/node/shvnode.h
+++ b/libshviotqt/src/node/shvnode.h
@@ -14,7 +14,7 @@
 
 #include <cstddef>
 
-namespace shv::chainpack { class AccessGrant; }
+namespace shv::chainpack { struct AccessGrant; }
 namespace shv::core { namespace utils { class ShvJournalEntry; }}
 
 


### PR DESCRIPTION
Found by Clang.

/home/vk/git/shv/3rdparty/libshv/libshvchainpack/include/shv/chainpack/../../../src/chainpack/accessgrant.h:60:1: warning: 'AccessGrant' defined as a struct here but previously declared as a class; this is valid, but may result in linker errors under the Microsoft C++ ABI [-Wmismatched-tags] struct SHVCHAINPACK_DECL_EXPORT AccessGrant
^
/home/vk/git/shv/3rdparty/libshv/libshviotqt/include/shv/iotqt/node/../../../../src/node/shvnode.h:17:28: note: did you mean struct here? namespace shv::chainpack { class AccessGrant; }