### PR TITLE
Make AbstractShvJournal::addToSnapshot public

### DIFF
--- a/libshvcore/include/shv/core/utils/abstractshvjournal.h
+++ b/libshvcore/include/shv/core/utils/abstractshvjournal.h
@@ -1,0 +1,1 @@
+#include "../../../../src/utils/abstractshvjournal.h"

--- a/libshvcore/src/utils/abstractshvjournal.h
+++ b/libshvcore/src/utils/abstractshvjournal.h
@@ -37,7 +37,6 @@ public:
 	virtual shv::chainpack::RpcValue getLog(const ShvGetLogParams &params) = 0;
 	virtual shv::chainpack::RpcValue getSnapShotMap();
 	void clearSnapshot();
-protected:
 	static void addToSnapshot(ShvSnapshot &snapshot, const ShvJournalEntry &entry);
 protected:
 	ShvSnapshot m_snapshot;


### PR DESCRIPTION
Need it for the reimplementation of getLog.