### PR TITLE
Fix ambiguous RpcValue::Int/UInt ctors

### DIFF
--- a/libshvchainpack/src/chainpack/rpcvalue.cpp
+++ b/libshvchainpack/src/chainpack/rpcvalue.cpp
@@ -455,10 +455,15 @@ RpcValue RpcValue::fromType(RpcValue::Type t) noexcept
 RpcValue::RpcValue(std::nullptr_t) noexcept : m_ptr(std::make_shared<ChainPackNull>()) {}
 RpcValue::RpcValue(double value) : m_ptr(std::make_shared<ChainPackDouble>(value)) {}
 RpcValue::RpcValue(RpcValue::Decimal value) : m_ptr(std::make_shared<ChainPackDecimal>(std::move(value))) {}
-RpcValue::RpcValue(int32_t value) : m_ptr(std::make_shared<ChainPackInt>(value)) {}
-RpcValue::RpcValue(uint32_t value) : m_ptr(std::make_shared<ChainPackUInt>(value)) {}
-RpcValue::RpcValue(int64_t value) : m_ptr(std::make_shared<ChainPackInt>(value)) {}
-RpcValue::RpcValue(uint64_t value) : m_ptr(std::make_shared<ChainPackUInt>(value)) {}
+RpcValue::RpcValue(short value) : m_ptr(std::make_shared<ChainPackInt>(value)) {}
+RpcValue::RpcValue(int value) : m_ptr(std::make_shared<ChainPackInt>(value)) {}
+RpcValue::RpcValue(long value) : m_ptr(std::make_shared<ChainPackInt>(value)) {}
+RpcValue::RpcValue(long long value) : m_ptr(std::make_shared<ChainPackInt>(value)) {}
+RpcValue::RpcValue(unsigned short value) : m_ptr(std::make_shared<ChainPackUInt>(value)) {}
+RpcValue::RpcValue(unsigned int value) : m_ptr(std::make_shared<ChainPackUInt>(value)) {}
+RpcValue::RpcValue(unsigned long value) : m_ptr(std::make_shared<ChainPackUInt>(value)) {}
+RpcValue::RpcValue(unsigned long long value) : m_ptr(std::make_shared<ChainPackUInt>(value)) {}
+
 RpcValue::RpcValue(bool value) : m_ptr(std::make_shared<ChainPackBoolean>(value)) {}
 RpcValue::RpcValue(const DateTime &value) : m_ptr(std::make_shared<ChainPackDateTime>(value)) {}
 

--- a/libshvchainpack/src/chainpack/rpcvalue.h
+++ b/libshvchainpack/src/chainpack/rpcvalue.h
@@ -344,10 +344,14 @@ public:
 	RpcValue(std::nullptr_t) noexcept;  // Null
 	RpcValue(bool value);               // Bool
 
-	RpcValue(int32_t value);                // Int
-	RpcValue(uint32_t value);                // UInt
-	RpcValue(int64_t value);                // Int
-	RpcValue(uint64_t value);                // UInt
+	RpcValue(short value);              // Int
+	RpcValue(int value);                // Int
+	RpcValue(long value);               // Int
+	RpcValue(long long value);          // Int
+	RpcValue(unsigned short value);     // UInt
+	RpcValue(unsigned int value);       // UInt
+	RpcValue(unsigned long value);      // UInt
+	RpcValue(unsigned long long value); // UInt
 	RpcValue(double value);             // Double
 	RpcValue(Decimal value);             // Decimal
 	RpcValue(const DateTime &value);


### PR DESCRIPTION
RpcValue doesn't really care about the size of the integer, it only cares about signedness. Having fixed width integer constructors meant that on some platforms (arm/wasm), they were ambiguous. Example, on ARM:

1) `long int` is 32 bit
2) `int` is also 32 bit
3) `int32_t` is typedefed to `int`, so this ctor can't be used for `long
   int`
4) this makes the Int/UInt ctors ambiguous for `long int`

Fix this by created constructors for all integer types.