### PR TITLE
libshvcoreqt: Improve joinpath

### DIFF
--- a/libshvcoreqt/CMakeLists.txt
+++ b/libshvcoreqt/CMakeLists.txt
@@ -28,6 +28,7 @@ endfunction(add_shvcoreqt_test)
 
 if(BUILD_TESTING)
 	add_shvcoreqt_test(rpc_variant)
+	add_shvcoreqt_test(join_path)
 endif()
 
 install(TARGETS libshvcoreqt)

--- a/libshvcoreqt/src/utils.cpp
+++ b/libshvcoreqt/src/utils.cpp
@@ -31,6 +31,11 @@ chainpack::RpcValue Utils::stringListToRpcValue(const QStringList &sl)
 	return rpc::stringListToRpcValue(sl);
 }
 
+std::string Utils::joinPath(const std::string& p1, const std::string& p2)
+{
+	return core::Utils::joinPath(core::StringView(p1), core::StringView(p2));
+}
+
 QString Utils::joinPath(const QString &p1, const QString &p2)
 {
 	QStringView sv1(p1);
@@ -44,11 +49,6 @@ QString Utils::joinPath(const QString &p1, const QString &p2)
 	if(sv1.isEmpty())
 		return sv2.toString();
 	return sv1.toString() + '/' + sv2.toString();
-}
-
-QString Utils::joinPath(const QString &p1, const QString &p2, const QString &p3)
-{
-	return joinPath(joinPath(p1, p2), p3);
 }
 
 bool Utils::isValueNotAvailable(const QVariant &val)

--- a/libshvcoreqt/tests/test_join_path.cpp
+++ b/libshvcoreqt/tests/test_join_path.cpp
@@ -7,9 +7,9 @@ doctest::String toString(const QString& str) {
 	return str.toStdString().c_str();
 }
 
+using shv::coreqt::Utils;
 DOCTEST_TEST_CASE("joinPath")
 {
-	using shv::coreqt::Utils;
 
 	QString prefix;
 	QString suffix;
@@ -74,3 +74,42 @@ DOCTEST_TEST_CASE("joinPath")
 	REQUIRE(Utils::joinPath(prefix, suffix) == result);
 }
 
+DOCTEST_TEST_CASE("joinPath - variadic arguments")
+{
+	// The function takes any number of args.
+	REQUIRE(Utils::joinPath(QString("a")) == "a");
+	REQUIRE(Utils::joinPath(QString("a"), QString("b")) == "a/b");
+	REQUIRE(Utils::joinPath(QString("a"), QString("b"), QString("c")) == "a/b/c");
+	REQUIRE(Utils::joinPath(QString("a"), QString("b"), QString("c"), QString("d")) == "a/b/c/d");
+	REQUIRE(Utils::joinPath(QString("a"), QString("b"), QString("c"), QString("d"), QString("e")) == "a/b/c/d/e");
+
+	// The function supports std::string.
+	REQUIRE(Utils::joinPath(QString("a"), std::string("b")) == "a/b");
+	REQUIRE(Utils::joinPath(std::string("a"), QString("b")) == "a/b");
+	REQUIRE(Utils::joinPath(std::string("a"), QString("b"), std::string("c")) == "a/b/c");
+	REQUIRE(Utils::joinPath(QString("a"), std::string("b"), QString("c")) == "a/b/c");
+	REQUIRE(Utils::joinPath(QString("a"), QString("b"), std::string("c")) == "a/b/c");
+
+	// The function supports character literals.
+	REQUIRE(Utils::joinPath("a") == "a");
+	REQUIRE(Utils::joinPath("a", "b") == "a/b");
+	REQUIRE(Utils::joinPath(QString("a"), "b") == "a/b");
+	REQUIRE(Utils::joinPath("a", std::string("b")) == "a/b");
+
+	// The function can return either a QString or an std::string.
+	REQUIRE(Utils::joinPath<QString>("a", "b") == "a/b");
+	REQUIRE(Utils::joinPath<QString>("a", std::string("b")) == "a/b");
+	REQUIRE(Utils::joinPath<QString>(QString("a"), "b") == "a/b");
+	REQUIRE(Utils::joinPath<QString>(QString("a"), std::string("b")) == "a/b");
+	REQUIRE(Utils::joinPath<QString>(std::string("a"), QString("b")) == "a/b");
+	REQUIRE(Utils::joinPath<QString>(std::string("a"), std::string("b")) == "a/b");
+	REQUIRE(Utils::joinPath<std::string>("a", "b") == "a/b");
+	REQUIRE(Utils::joinPath<std::string>("a", std::string("b")) == "a/b");
+	REQUIRE(Utils::joinPath<std::string>(QString("a"), "b") == "a/b");
+	REQUIRE(Utils::joinPath<std::string>(std::string("a"), QString("b"), std::string("c")) == "a/b/c");
+	REQUIRE(Utils::joinPath<std::string>(std::string("a"), QString("b"), QString("c")) == "a/b/c");
+	REQUIRE(Utils::joinPath<std::string>(std::string("a"), std::string("b")) == "a/b");
+	// QString::toStdString can still be used manually, however, the function will be less efficient about conversions
+	// between the string types.
+	REQUIRE(Utils::joinPath("a", std::string("b")).toStdString() == "a/b");
+}

--- a/libshvcoreqt/tests/test_join_path.cpp
+++ b/libshvcoreqt/tests/test_join_path.cpp
@@ -1,0 +1,76 @@
+#define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
+#include <shv/coreqt/utils.h>
+
+#include <doctest/doctest.h>
+
+doctest::String toString(const QString& str) {
+	return str.toStdString().c_str();
+}
+
+DOCTEST_TEST_CASE("joinPath")
+{
+	using shv::coreqt::Utils;
+
+	QString prefix;
+	QString suffix;
+	QString result;
+
+	DOCTEST_SUBCASE("regular")
+	{
+		prefix = "foo";
+		suffix = "bar";
+		result = "foo/bar";
+	}
+
+	DOCTEST_SUBCASE("trailing slash left operand")
+	{
+		prefix = "foo/";
+		suffix = "bar";
+		result = "foo/bar";
+	}
+
+	DOCTEST_SUBCASE("trailing slash right operand")
+	{
+		prefix = "foo";
+		suffix = "bar/";
+		result = "foo/bar/";
+	}
+
+	DOCTEST_SUBCASE("trailing slash both operands")
+	{
+		prefix = "foo/";
+		suffix = "bar/";
+		result = "foo/bar/";
+	}
+
+	DOCTEST_SUBCASE("left operand empty")
+	{
+		prefix = "";
+		suffix = "bar";
+		result = "bar";
+	}
+
+	DOCTEST_SUBCASE("right operand empty")
+	{
+		prefix = "foo";
+		suffix = "";
+		result = "foo";
+	}
+
+	DOCTEST_SUBCASE("leading slash left operand")
+	{
+		prefix = "/foo";
+		suffix = "bar";
+		result = "/foo/bar";
+	}
+
+	DOCTEST_SUBCASE("leading slash right operand")
+	{
+		prefix = "foo";
+		suffix = "/bar";
+		result = "foo/bar";
+	}
+
+	REQUIRE(Utils::joinPath(prefix, suffix) == result);
+}
+


### PR DESCRIPTION
Joining paths is always a pain, when you have a mix of QString and std::string. This patch adds a special templated function, that's able automatically convert the input strings into the desired result value.