### PR TITLE
Add support for NULL chainpack serialization buffer #202

### DIFF
--- a/libshvchainpack/c/ccpcp.h
+++ b/libshvchainpack/c/ccpcp.h
@@ -49,17 +49,19 @@ typedef struct ccpcp_pack_context {
 	ccpcp_pack_overflow_handler handle_pack_overflow;
 	void *custom_context;
 	ccpcp_cpon_pack_options cpon_options;
+	size_t bytes_written;
 } ccpcp_pack_context;
 
-void ccpcp_pack_context_init(ccpcp_pack_context* pack_context, void *data, size_t length, ccpcp_pack_overflow_handler hpo);
+void ccpcp_pack_context_init(ccpcp_pack_context* pack_context, void *data, size_t length, ccpcp_pack_overflow_handler poh);
+void ccpcp_pack_context_dry_run_init(ccpcp_pack_context* pack_context);
 
 // try to make size_hint bytes space in pack_context
 // returns number of bytes available in pack_context buffer, can be < size_hint, but always > 0
 // returns 0 if fails
-size_t ccpcp_pack_make_space(ccpcp_pack_context* pack_context, size_t size_hint);
-char *ccpcp_pack_reserve_space(ccpcp_pack_context* pack_context, size_t more);
-void ccpcp_pack_copy_byte (ccpcp_pack_context* pack_context, uint8_t b);
-void ccpcp_pack_copy_bytes (ccpcp_pack_context* pack_context, const void *str, size_t len);
+//size_t ccpcp_pack_make_space(ccpcp_pack_context* pack_context, size_t size_hint);
+//char *ccpcp_pack_reserve_space(ccpcp_pack_context* pack_context, size_t more);
+size_t ccpcp_pack_copy_byte(ccpcp_pack_context* pack_context, uint8_t b);
+size_t ccpcp_pack_copy_bytes(ccpcp_pack_context* pack_context, const void *str, size_t len);
 //void ccpcp_pack_copy_bytes_cpon_string_escaped (ccpcp_pack_context* pack_context, const void *str, size_t len);
 
 //=========================== UNPACK ============================

--- a/libshvchainpack/c/ccpcp_convert.c
+++ b/libshvchainpack/c/ccpcp_convert.c
@@ -1,8 +1,15 @@
 #include "cchainpack.h"
 #include "ccpon.h"
 
+#include <assert.h>
+
 void ccpcp_convert(ccpcp_unpack_context* in_ctx, ccpcp_pack_format in_format, ccpcp_pack_context* out_ctx, ccpcp_pack_format out_format)
 {
+	if(!in_ctx->container_stack) {
+		// ccpcp_convert() cannot worj without input context container state set
+		in_ctx->err_no = CCPCP_RC_LOGICAL_ERROR;
+		return;
+	}
 	bool o_cpon_input = (in_format == CCPCP_Cpon);
 	bool o_chainpack_output = (out_format == CCPCP_ChainPack);
 	//int prev_item = CCPCP_ITEM_INVALID;
@@ -240,7 +247,6 @@ void ccpcp_convert(ccpcp_unpack_context* in_ctx, ccpcp_pack_format in_format, cc
 			break;
 		}
 		}
-		//prev_item = in_ctx->item.type;
 		{
 			ccpcp_container_state *top_state = ccpcp_unpack_context_top_container_state(in_ctx);
 			// take just one object from stream

--- a/libshvchainpack/c/ccpon.c
+++ b/libshvchainpack/c/ccpon.c
@@ -338,19 +338,6 @@ static void	*memcpy(void *dst, const void *src, size_t n)
 #endif
 
 //============================   P A C K   =================================
-void ccpcp_pack_context_init (ccpcp_pack_context* pack_context, void *data, size_t length, ccpcp_pack_overflow_handler hpo)
-{
-	pack_context->start = pack_context->current = (char*)data;
-	pack_context->end = pack_context->start + length;
-	pack_context->err_no = 0;
-	pack_context->handle_pack_overflow = hpo;
-	pack_context->err_no = CCPCP_RC_OK;
-	pack_context->cpon_options.indent = NULL;
-	pack_context->cpon_options.json_output = 0;
-	pack_context->nest_count = 0;
-	pack_context->custom_context = NULL;
-}
-
 void ccpon_pack_copy_str(ccpcp_pack_context *pack_context, const char *str)
 {
 	size_t len = strlen(str);
@@ -449,10 +436,7 @@ void ccpon_pack_double(ccpcp_pack_context* pack_context, double d)
 		pack_context->err_no = CCPCP_RC_LOGICAL_ERROR;
 		return;
 	}
-	char *p = ccpcp_pack_reserve_space(pack_context, n);
-	if(p) {
-		memcpy(p, str, n);
-	}
+	ccpcp_pack_copy_bytes(pack_context, str, n);
 }
 
 void ccpon_pack_date_time(ccpcp_pack_context *pack_context, int64_t epoch_msecs, int min_from_utc)
@@ -566,10 +550,8 @@ void ccpon_pack_list_begin(ccpcp_pack_context *pack_context)
 	if (pack_context->err_no)
 		return;
 
-	char *p = ccpcp_pack_reserve_space(pack_context, 1);
-	if(p)
-		*p = CCPON_C_LIST_BEGIN;
-	start_block(pack_context);
+	if(ccpcp_pack_copy_byte(pack_context, CCPON_C_LIST_BEGIN) > 0)
+		start_block(pack_context);
 }
 
 void ccpon_pack_list_end(ccpcp_pack_context *pack_context, bool is_oneliner)
@@ -578,9 +560,7 @@ void ccpon_pack_list_end(ccpcp_pack_context *pack_context, bool is_oneliner)
 		return;
 
 	end_block(pack_context, is_oneliner);
-	char *p = ccpcp_pack_reserve_space(pack_context, 1);
-	if(p)
-		*p = CCPON_C_LIST_END;
+	ccpcp_pack_copy_byte(pack_context, CCPON_C_LIST_END);
 }
 
 void ccpon_pack_map_begin(ccpcp_pack_context *pack_context)
@@ -588,10 +568,8 @@ void ccpon_pack_map_begin(ccpcp_pack_context *pack_context)
 	if (pack_context->err_no)
 		return;
 
-	char *p = ccpcp_pack_reserve_space(pack_context, 1);
-	if(p)
-		*p = CCPON_C_MAP_BEGIN;
-	start_block(pack_context);
+	if(ccpcp_pack_copy_byte(pack_context, CCPON_C_MAP_BEGIN))
+		start_block(pack_context);
 }
 
 void ccpon_pack_map_end(ccpcp_pack_context *pack_context, bool is_oneliner)
@@ -600,10 +578,7 @@ void ccpon_pack_map_end(ccpcp_pack_context *pack_context, bool is_oneliner)
 		return;
 
 	end_block(pack_context, is_oneliner);
-	char *p = ccpcp_pack_reserve_space(pack_context, 1);
-	if(p) {
-		*p = CCPON_C_MAP_END;
-	}
+	ccpcp_pack_copy_byte(pack_context, CCPON_C_MAP_END);
 }
 
 void ccpon_pack_imap_begin(ccpcp_pack_context* pack_context)
@@ -625,10 +600,8 @@ void ccpon_pack_meta_begin(ccpcp_pack_context *pack_context)
 	if (pack_context->err_no)
 		return;
 
-	char *p = ccpcp_pack_reserve_space(pack_context, 1);
-	if(p)
-		*p = CCPON_C_META_BEGIN;
-	start_block(pack_context);
+	if(ccpcp_pack_copy_byte(pack_context, CCPON_C_META_BEGIN) > 0)
+		start_block(pack_context);
 }
 
 void ccpon_pack_meta_end(ccpcp_pack_context *pack_context, bool is_oneliner)
@@ -637,10 +610,7 @@ void ccpon_pack_meta_end(ccpcp_pack_context *pack_context, bool is_oneliner)
 		return;
 
 	end_block(pack_context, is_oneliner);
-	char *p = ccpcp_pack_reserve_space(pack_context, 1);
-	if(p) {
-		*p = CCPON_C_META_END;
-	}
+	ccpcp_pack_copy_byte(pack_context, CCPON_C_META_END);
 }
 
 static char* copy_data_escaped(ccpcp_pack_context* pack_context, const void* str, size_t len)


### PR DESCRIPTION
To measure buffer size needed to pack use ccpcp_pack_context_dry_run_init() Packed size can be found in ccpcp_pack_context::bytes_written field

For example see: test_dry_run_int() in test_ccpcp.c