### PR TITLE
Fix build error when ranges are not available

### DIFF
--- a/libshvcoreqt/src/utils.cpp
+++ b/libshvcoreqt/src/utils.cpp
@@ -166,7 +166,12 @@ QJsonValue utils::rpcValueToJson(const shv::chainpack::RpcValue& v)
 	}
 	case shv::chainpack::RpcValue::Type::List: {
 		QJsonArray arr;
+#if defined(__cpp_lib_ranges)
 		std::ranges::transform(v.asList(), std::back_inserter(arr), [] (const shv::chainpack::RpcValue& elem) { return rpcValueToJson(elem); });
+#else
+		auto list = v.asList();
+		std::transform(list.begin(), list.end(), std::back_inserter(arr), [] (const shv::chainpack::RpcValue& elem) { return rpcValueToJson(elem); });
+#endif
 		return arr;
 	}
 	case shv::chainpack::RpcValue::Type::Map: {


### PR DESCRIPTION
WASM doesn't have this it seems.