### PR TITLE
Fix undefined behavior

### DIFF
--- a/libshvchainpack/c/ccpcp.c
+++ b/libshvchainpack/c/ccpcp.c
@@ -21,7 +21,10 @@ const char *ccpcp_error_string(int err_no)
 void ccpcp_pack_context_init (ccpcp_pack_context* pack_context, void *data, size_t length, ccpcp_pack_overflow_handler poh)
 {
 	pack_context->start = pack_context->current = (char*)data;
-	pack_context->end = pack_context->start + length;
+	pack_context->end = pack_context->start;
+	if (length) {
+		pack_context->end += length;
+	}
 	pack_context->err_no = 0;
 	pack_context->handle_pack_overflow = poh;
 	pack_context->err_no = CCPCP_RC_OK;


### PR DESCRIPTION
    /home/vk/git/eyas/3rdparty/libshv/libshvchainpack/c/ccpcp.c:24:42: runtime error: applying zero offset to null pointer
        *0 0x5591d2108aa3 in ccpcp_pack_context_init /home/vk/git/eyas/3rdparty/libshv/libshvchainpack/c/ccpcp.c:24:42
        *1 0x5591d210918e in ccpcp_pack_context_dry_run_init /home/vk/git/eyas/3rdparty/libshv/libshvchainpack/c/ccpcp.c:37:2
        *2 0x5591d20fb242 in test_dry_run_cpon /home/vk/git/eyas/3rdparty/libshv/libshvchainpack/c/tests/test_ccpcp.c:375:3
        *3 0x5591d20fad1f in test_cpons /home/vk/git/eyas/3rdparty/libshv/libshvchainpack/c/tests/test_ccpcp.c:672:3
        *4 0x5591d20fc4fe in main /home/vk/git/eyas/3rdparty/libshv/libshvchainpack/c/tests/test_ccpcp.c:769:2
        *5 0x7f345b82078f  (/usr/lib/libc.so.6+0x2378f) (BuildId: 4a4bec3d95a1804443e852958fe59ed461135ce9)
        *6 0x7f345b820849 in __libc_start_main (/usr/lib/libc.so.6+0x23849) (BuildId: 4a4bec3d95a1804443e852958fe59ed461135ce9)
        *7 0x5591d1ff80a4 in _start (/home/vk/git/eyas/build/3rdparty/libshv/libshvchainpack/c/test_ccpcp+0x3e0a4) (BuildId: 34e411833fb7168b8123f1d1019423ffb07ea97b)
    
    SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/vk/git/eyas/3rdparty/libshv/libshvchainpack/c/ccpcp.c:24:42 in