### PR TITLE
ldap: Add missing return

### DIFF
--- a/libshvbroker/src/brokerapp.cpp
+++ b/libshvbroker/src/brokerapp.cpp
@@ -624,6 +624,7 @@ void BrokerApp::checkLogin(const chainpack::UserLoginContext &ctx, const std::fu
 		});
 		connect(auth_thread, &LdapAuthThread::finished, auth_thread, &QObject::deleteLater);
 		auth_thread->start();
+		return;
 	}
 #endif
 	cb(result);


### PR DESCRIPTION
Without the return, we would call cb(result), which is not what we want (because the LDAP auth would be completely bypassed.