### PR TITLE
Ignore warning on GCC

### DIFF
--- a/libshvcoreqt/src/rpc.cpp
+++ b/libshvcoreqt/src/rpc.cpp
@@ -152,6 +152,9 @@ shv::chainpack::RpcValue stringListToRpcValue(const QStringList &sl)
 
 } // namespace shv
 
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=109503
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wattributes"
 template<> QString shv::chainpack::RpcValue::to<QString>() const
 {
 	return QString::fromStdString(asString());
@@ -164,3 +167,4 @@ template<> QDateTime shv::chainpack::RpcValue::to<QDateTime>() const
 	}
 	return QDateTime::fromMSecsSinceEpoch(toDateTime().msecsSinceEpoch(), Qt::TimeSpec::UTC);
 }
+#pragma GCC diagnostic pop


### PR DESCRIPTION
On my pc, GCC gives this warning, which is obviously wrong.

/home/vk/git/shv/3rdparty/libshv/libshvcoreqt/src/rpc.cpp:155:20: error: ‘T shv::chainpack::RpcValue::to() const [with T = QString]’: visibility attribute ignored because it conflicts with previous declaration [-Werror=attributes]
  155 | template<> QString shv::chainpack::RpcValue::to<QString>() const
      |                    ^~~
In file included from /home/vk/git/shv/3rdparty/libshv/libshvcoreqt/src/rpc.cpp:1:
/home/vk/git/shv/3rdparty/libshv/libshvcoreqt/src/rpc.h:22:42: note: previous declaration of ‘T shv::chainpack::RpcValue::to() const [with T = QString]’
   22 | template<> SHVCOREQT_DECL_EXPORT QString shv::chainpack::RpcValue::to<QString>() const;
      |                                          ^~~
/home/vk/git/shv/3rdparty/libshv/libshvcoreqt/src/rpc.cpp:160:22: error: ‘T shv::chainpack::RpcValue::to() const [with T = QDateTime]’: visibility attribute ignored because it conflicts with previous declaration [-Werror=attributes]
  160 | template<> QDateTime shv::chainpack::RpcValue::to<QDateTime>() const
      |                      ^~~
/home/vk/git/shv/3rdparty/libshv/libshvcoreqt/src/rpc.h:23:44: note: previous declaration of ‘T shv::chainpack::RpcValue::to() const [with T = QDateTime]’
   23 | template<> SHVCOREQT_DECL_EXPORT QDateTime shv::chainpack::RpcValue::to<QDateTime>() const;
      |                                            ^~~

I'm not sure whether the code is valid or not, but since the waning message is wrong, let's just ignore it.