### PR TITLE
CI: Always build with LDAP, even for linters

### DIFF
--- a/.github/actions/cmake/action.yml
+++ b/.github/actions/cmake/action.yml
@@ -32,6 +32,6 @@ runs:
         modules: ${{ inputs.modules }}
 
     - name: Configure CMake
-      run: CFLAGS="-Werror" CXXFLAGS="-Werror" cmake -G Ninja -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ${{ inputs.additional_cmake_args }} -DUSE_QT6=${{ inputs.use_qt6 }} -DWITH_CLI_EXAMPLES=ON -DWITH_GUI_EXAMPLES=ON
+      run: CFLAGS="-Werror" CXXFLAGS="-Werror" cmake -G Ninja -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DUSE_QT6=${{ inputs.use_qt6 }} -DWITH_CLI_EXAMPLES=ON -DWITH_GUI_EXAMPLES=ON -DWITH_LDAP=ON ${{ inputs.additional_cmake_args }}
       shell: bash
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -40,7 +40,6 @@ jobs:
           qt_version: 6.5.0
           use_qt6: ON
           modules: qtserialport qtwebsockets
-          additional_cmake_args: -DWITH_LDAP=ON
 
       - name: Build
         run: cmake --build ${{github.workspace}}/build --parallel "$(nproc)"


### PR DESCRIPTION
Linter workflows would choke as soon as ldap.{cpp,h} changes. Also, generally, I'd like the ldap code to be checked. Hopefully the LDAP code builds with Qt5 (no reason it shouldn't imho).