### PR TITLE
libshv: use QByteArray in QCryptographicHash::addData for QT prior to 6.3

### DIFF
--- a/libshvbroker/src/aclmanager.cpp
+++ b/libshvbroker/src/aclmanager.cpp
@@ -182,7 +182,7 @@ chainpack::UserLoginResult AclManager::checkPassword(const chainpack::UserLoginC
 
 		std::string nonce = login_context.serverNounce + acl_pwd.password;
 		QCryptographicHash hash(QCryptographicHash::Algorithm::Sha1);
-#if QT_VERSION_MAJOR >= 6
+#if QT_VERSION_MAJOR >= 6 && QT_VERSION_MINOR >= 3
 		hash.addData(QByteArrayView(nonce.data(), static_cast<int>(nonce.length())));
 #else
 		hash.addData(nonce.data(), static_cast<int>(nonce.length()));

--- a/libshvbroker/src/currentclientshvnode.cpp
+++ b/libshvbroker/src/currentclientshvnode.cpp
@@ -14,7 +14,7 @@ using namespace std;
 static string sha1_hex(const std::string &s)
 {
 	QCryptographicHash hash(QCryptographicHash::Algorithm::Sha1);
-#if QT_VERSION_MAJOR >= 6
+#if QT_VERSION_MAJOR >= 6 && QT_VERSION_MINOR >= 3
 	hash.addData(QByteArrayView(s.data(), static_cast<int>(s.length())));
 #else
 	hash.addData(s.data(), static_cast<int>(s.length()));

--- a/libshvbroker/src/tunnelsecretlist.cpp
+++ b/libshvbroker/src/tunnelsecretlist.cpp
@@ -50,7 +50,7 @@ std::string TunnelSecretList::createSecret()
 		data[i] = std::rand();
 #endif
 	QCryptographicHash hash(QCryptographicHash::Algorithm::Sha1);
-#if QT_VERSION_MAJOR >= 6
+#if QT_VERSION_MAJOR >= 6 && QT_VERSION_MINOR >= 3
 	hash.addData(QByteArrayView(reinterpret_cast<const char*>(data.data()), DATA_LEN * sizeof(data[0])));
 #else
 	hash.addData(reinterpret_cast<const char*>(data.data()), DATA_LEN * sizeof(data[0]));

--- a/libshviotqt/src/node/filenode.cpp
+++ b/libshviotqt/src/node/filenode.cpp
@@ -77,7 +77,7 @@ cp::RpcValue FileNode::callMethod(const shv::iotqt::node::ShvNode::StringViewLis
 	if(method == M_HASH) {
 		shv::chainpack::RpcValue::Blob bytes = read(shv_path, params).asBlob();
 		QCryptographicHash h(QCryptographicHash::Sha1);
-#if QT_VERSION_MAJOR >= 6
+#if QT_VERSION_MAJOR >= 6 && QT_VERSION_MINOR >= 3
 		h.addData(QByteArrayView(reinterpret_cast<const char*>(bytes.data()), static_cast<int>(bytes.size())));
 #else
 		h.addData(reinterpret_cast<const char*>(bytes.data()), static_cast<int>(bytes.size()));

--- a/libshviotqt/src/rpc/clientconnection.cpp
+++ b/libshviotqt/src/rpc/clientconnection.cpp
@@ -387,7 +387,7 @@ chainpack::RpcValue ClientConnection::createLoginParams(const chainpack::RpcValu
 			pwd = utils::sha1Hex(pwd); /// SHA1 password must be 40 chars long, it is considered to be plain if shorter
 		std::string pn = server_nonce + pwd;
 		QCryptographicHash hash(QCryptographicHash::Algorithm::Sha1);
-#if QT_VERSION_MAJOR >= 6
+#if QT_VERSION_MAJOR >= 6 && QT_VERSION_MINOR >= 3
 		hash.addData(QByteArrayView(pn.data(), static_cast<int>(pn.length())));
 #else
 		hash.addData(pn.data(), static_cast<int>(pn.length()));

--- a/libshviotqt/src/utils.cpp
+++ b/libshviotqt/src/utils.cpp
@@ -10,7 +10,7 @@ namespace shv::iotqt::utils {
 std::string sha1Hex(const std::string &s)
 {
 	QCryptographicHash hash(QCryptographicHash::Algorithm::Sha1);
-#if QT_VERSION_MAJOR >= 6
+#if QT_VERSION_MAJOR >= 6 && QT_VERSION_MINOR >= 3
 	hash.addData(QByteArrayView(s.data(), static_cast<int>(s.length())));
 #else
 	hash.addData(s.data(), static_cast<int>(s.length()));


### PR DESCRIPTION
`QCryptographicHash::addData` uses `QByteArray` for versions prior to QT 6.3. Therefore the current check `QT_VERSION_MAJOR >= 6` is not sufficient and build results in error if QT 6.2 (in long term Ubuntu 22.04 for example) is used. This commit adds additional condition `QT_VERSION_MINOR >= 3`.