### PR TITLE
Remove "warning" when building without LDAP

### DIFF
--- a/libshvbroker/src/brokerapp.cpp
+++ b/libshvbroker/src/brokerapp.cpp
@@ -1325,4 +1325,5 @@ void BrokerApp::setAclManager(AclManager *mng)
 	m_aclManager = mng;
 }
 }
+// For LdapAuthThread.
 #include <brokerapp.moc>


### PR DESCRIPTION
```
AutoMoc: /home/vk/git/shvspy/3rdparty/libshv/libshvbroker/src/brokerapp.cpp:0:1: note: No relevant classes found. No output generated.
```

The warning might be confusing, and someone might accidentally remove the line. It is needed when building with LDAP.