### PR TITLE
libshvbroker: Don't check for SSL

### DIFF
--- a/libshvbroker/src/brokerapp.cpp
+++ b/libshvbroker/src/brokerapp.cpp
@@ -663,7 +663,7 @@ private:
 };
 #endif
 
-void BrokerApp::checkLogin(const chainpack::UserLoginContext &ctx, bool ssl, const QObject* connection_ctx, const std::function<void(chainpack::UserLoginResult)> cb)
+void BrokerApp::checkLogin(const chainpack::UserLoginContext &ctx, const QObject* connection_ctx, const std::function<void(chainpack::UserLoginResult)> cb)
 {
 	auto result = BrokerApp::instance()->aclManager()->checkPassword(ctx);
 	// If the user exists in the ACL manager, we'll take the result as decisive.
@@ -674,8 +674,7 @@ void BrokerApp::checkLogin(const chainpack::UserLoginContext &ctx, bool ssl, con
 
 #ifdef WITH_SHV_LDAP
 	if (m_ldapConfig) {
-		if (ssl) {
-			if (ctx.userLogin().loginType == chainpack::IRpcConnection::LoginType::Plain) {
+		if (ctx.userLogin().loginType == chainpack::IRpcConnection::LoginType::Plain) {
 				auto auth_thread = new LdapAuthThread(ctx, *m_ldapConfig);
 				connect(auth_thread, &LdapAuthThread::resultReady, connection_ctx, [cb, user_name = ctx.userLogin().user] (const auto& ldap_result, const auto& shv_groups) {
 					BrokerApp::instance()->aclManager()->setGroupForLdapUser(user_name, shv_groups);
@@ -684,14 +683,10 @@ void BrokerApp::checkLogin(const chainpack::UserLoginContext &ctx, bool ssl, con
 				connect(auth_thread, &LdapAuthThread::finished, auth_thread, &QObject::deleteLater);
 				auth_thread->start();
 				return;
-			}
-			result.loginError += " Authentication over LDAP disabled, because your client probably doesn't support it. Please update your client to enable LDAP authentication.";
-		} else {
-			result.loginError += " To authenticate over LDAP, please enable SSL.";
 		}
+		result.loginError += " Authentication over LDAP requires sending a plaintext password. Please an SSL connection.";
 	}
 #else
-	(void)ssl;
 	(void)connection_ctx;
 #endif
 	cb(result);

--- a/libshvbroker/src/brokerapp.h
+++ b/libshvbroker/src/brokerapp.h
@@ -96,7 +96,7 @@ public:
 	void reloadConfigRemountDevices();
 	bool checkTunnelSecret(const std::string &s);
 
-	void checkLogin(const chainpack::UserLoginContext &ctx, bool ssl, const QObject* connection_ctx, const std::function<void(chainpack::UserLoginResult)> cb);
+	void checkLogin(const chainpack::UserLoginContext &ctx, const QObject* connection_ctx, const std::function<void(chainpack::UserLoginResult)> cb);
 
 	void sendNewLogEntryNotify(const std::string &msg);
 

--- a/libshvbroker/src/rpc/clientconnectiononbroker.cpp
+++ b/libshvbroker/src/rpc/clientconnectiononbroker.cpp
@@ -294,7 +294,7 @@ void ClientConnectionOnBroker::processLoginPhase()
 		return;
 	}
 	Super::processLoginPhase();
-	BrokerApp::instance()->checkLogin(m_userLoginContext, dynamic_cast<iotqt::rpc::SslSocket*>(m_socket) != nullptr, this, [this] (auto result) {
+	BrokerApp::instance()->checkLogin(m_userLoginContext, this, [this] (auto result) {
 		setLoginResult(result);
 	});
 }


### PR DESCRIPTION
And only for plaintext password. Clients should send plaintext password only with SSL, so suggesting users use it is valid.