### PR TITLE
rpcdriver: log all received data on ParseException

### DIFF
--- a/libshvchainpack/src/chainpack/rpcdriver.cpp
+++ b/libshvchainpack/src/chainpack/rpcdriver.cpp
@@ -271,6 +271,7 @@ void RpcDriver::processReadData()
 				return;
 			}
 			logRpcDataW() << "ERROR - RpcMessage header corrupted:" << e.msg();
+			logRpcDataW() << "The error occured in data:\n" << shv::chainpack::Utils::hexDump(m_readData);
 			onParseDataException(e);
 			return;
 		}


### PR DESCRIPTION
Displays a helpful information for debugging without the need to have a too verbose RpcData log level turned on.