### PR TITLE
libshviotqt: Do not add websocket.h always

### DIFF
--- a/libshviotqt/CMakeLists.txt
+++ b/libshviotqt/CMakeLists.txt
@@ -33,7 +33,6 @@ qt_add_library(libshviotqt
 	include/shv/iotqt/rpc/deviceconnection.h
 	include/shv/iotqt/rpc/tcpserver.h
 	include/shv/iotqt/rpc/rpcresponsecallback.h
-	include/shv/iotqt/rpc/websocket.h
 	include/shv/iotqt/rpc/socket.h
 	include/shv/iotqt/rpc/clientconnection.h
 	include/shv/iotqt/rpc/serverconnection.h
@@ -58,6 +57,7 @@ target_compile_definitions(libshviotqt PRIVATE SHVIOTQT_BUILD_DLL)
 
 if(WITH_SHV_WEBSOCKETS)
 	target_sources(libshviotqt PRIVATE
+		include/shv/iotqt/rpc/websocket.h
 		src/rpc/websocket.cpp
 		)
 	target_compile_definitions(libshviotqt PUBLIC WITH_SHV_WEBSOCKETS)


### PR DESCRIPTION
Having this unconditionally can lead to linking errors, if you have websockets disabled.

This is with `WITH_SHV_WEBSOCKETS=OFF`
```
C:/mingw-12/x86_64-12.1.0-release-posix-seh-rt_v10-rev3/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/12.1.0/../../../../x86_64-w64-mingw32/bin/ld.exe: CMakeFiles\libshviotqt.dir/objects.a(mocs_compilation.cpp.obj):mocs_compilation.cpp:(.rdata$_ZTVN3shv5iotqt3rpc9WebSocketE[_ZTVN3shv5iotqt3rpc9WebSocketE]+0x70): undefined reference to `shv::iotqt::rpc::WebSocket::connectToHost(QUrl const&)'
```