### PR TITLE
compat: Also try to find ssize_t in sys/types.h

### DIFF
--- a/libshvchainpack/c/include/shv/chainpack/compat.h
+++ b/libshvchainpack/c/include/shv/chainpack/compat.h
@@ -1,11 +1,5 @@
 #pragma once
-#ifdef __has_include
-	#if __has_include(<unistd.h>)
-		#include <unistd.h>
-	#endif
-#endif
-
-#ifndef __ssize_t_defined
+#ifdef _MSC_VER
 #include <stdint.h>
 typedef intmax_t ssize_t;
 #endif


### PR DESCRIPTION
On my machine, ssize_t is defined in both sys/types.h and unistd.h, but it appears NuttX defines it only in sys/types.h. Try to solve this by also including sys/types.h