### PR TITLE
github/workflows: fix Nix format check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -199,4 +199,4 @@ jobs:
       - name: Flake check
         run: nix --experimental-features 'nix-command flakes' flake check .
       - name: Format
-        run: nix --experimental-features 'nix-command flakes' fmt && git diff --exit-code
+        run: nix --experimental-features 'nix-command flakes' fmt . && git diff --exit-code


### PR DESCRIPTION
The new version of Nix no longer provides path to the source to the formatter and thus alejandra uses stdin instead and thus run fails.

https://github.com/NixOS/nix/pull/11438