### PR TITLE
Fix RpcCall resetting on all data chunks

### DIFF
--- a/libshviotqt/include/shv/iotqt/rpc/clientconnection.h
+++ b/libshviotqt/include/shv/iotqt/rpc/clientconnection.h
@@ -65,6 +65,8 @@ public:
 	void setCheckBrokerConnectedInterval(int ms);
 	int checkBrokerConnectedInterval() const;
 
+	void onRpcFrameReceived(chainpack::RpcFrame&&) override;
+	Q_SIGNAL void rpcFrameReceived();
 	Q_SIGNAL void rpcMessageReceived(const shv::chainpack::RpcMessage &msg);
 
 	bool isBrokerConnected() const;

--- a/libshviotqt/include/shv/iotqt/rpc/rpccall.h
+++ b/libshviotqt/include/shv/iotqt/rpc/rpccall.h
@@ -45,6 +45,7 @@ public:
 	void start(int time_out_msec, QObject *context, const CallBackFunction& cb);
 	void abort();
 	virtual void onRpcMessageReceived(const shv::chainpack::RpcMessage &msg);
+	void onRpcFrameReceived();
 private:
 	void onResponseMetaReceived(int request_id);
 	void onDataChunkReceived();
@@ -52,6 +53,7 @@ private:
 	CallBackFunction m_callBackFunction;
 	QTimer *m_timeoutTimer = nullptr;
 	bool m_responseMetaReceived = false;
+	bool m_responseFrameReceived = false;
 	bool m_isFinished = false;
 };
 

--- a/libshviotqt/src/rpc/clientconnection.cpp
+++ b/libshviotqt/src/rpc/clientconnection.cpp
@@ -812,6 +812,12 @@ void ClientConnection::processLoginPhase(const chainpack::RpcMessage &msg)
 	restartIfAutoConnect();
 }
 
+void ClientConnection::onRpcFrameReceived(chainpack::RpcFrame&& frame)
+{
+	emit rpcFrameReceived();
+	Super::onRpcFrameReceived(std::move(frame));
+}
+
 const char *ClientConnection::stateToString(ClientConnection::State state)
 {
 	switch (state) {


### PR DESCRIPTION
This hopefully fixes a situation where:
- RpcCall obtains response metadata
- Frame gets obtained too
- parsing of the RpcMessage fails
- onRpcMessageReceived never gets called, which means that the RpcCall never completes
- the timeout for the RpcCall gets refreshed on every dataChunkReceived, even though these messages are not the ones RpcCall requests

Ideally, the &ClientConnection::dataChunkReceived signal would supply the slot with the request id of the chunk being received, but that's a bit too difficult to implement, because the Socket class does not remember the requests ids.

In the situation, where the frame fails to parse as a RpcMessage, there are two situations that can happen:
1) Another message never arrives. In this case, the RpcCall will eventually
   timeout.
2) Another message arrives before RpcCall times out. In this case we could
   theoretically fail early in onRpcMessageReceived, because if we have a
   message frame, we know that this message is ours, but we already have the
   metadata for it. If it's not our message, then we'll never get the response,
   as meta and the frame can't intertwine with another message.

I have not implemented any special handling for the second situation, as the message will time out anyway. Ideally, we would like to fail early for all situations. For example, there could be a signal called "rpcFrameFailedToParse", and then, in both of the situations, we wouldn't really on the timeout timer. However, as this seems a bit took difficult to implement, I chose to go with the easy way.