### PR TITLE
Add .broker::mounts and .broker::mountedClientInfo methods

### DIFF
--- a/libshvbroker/CMakeLists.txt
+++ b/libshvbroker/CMakeLists.txt
@@ -17,6 +17,7 @@ qt_add_library(libshvbroker
 	src/rpc/ssl_common.cpp
 	src/subscriptionsnode.cpp
 	src/tunnelsecretlist.cpp
+	src/dotbrokernode.h src/dotbrokernode.cpp
 
 	include/shv/broker/shvbrokerglobal.h
 	include/shv/broker/tunnelsecretlist.h

--- a/libshvbroker/include/shv/broker/brokerapp.h
+++ b/libshvbroker/include/shv/broker/brokerapp.h
@@ -30,7 +30,6 @@ inline unsigned qHash(const std::string &s) noexcept //Q_DECL_NOEXCEPT_EXPR(noex
 #include <shv/broker/ldap/ldapconfig.h>
 #endif
 #include <shv/broker/azureconfig.h>
-#include <set>
 
 class QSocketNotifier;
 class QSqlDatabase;
@@ -104,6 +103,9 @@ public:
 
 	const std::string& brokerId() const;
 
+	rpc::ClientConnectionOnBroker* clientConnectionById(int connection_id);
+	std::vector<int> clientConnectionIds();
+
 protected:
 	virtual void initDbConfigSqlConnection();
 	virtual AclManager* createAclManager();
@@ -116,9 +118,6 @@ private:
 	void startTcpServers();
 
 	void startWebSocketServers();
-
-	rpc::ClientConnectionOnBroker* clientConnectionById(int connection_id);
-	std::vector<int> clientConnectionIds();
 
 	void createMasterBrokerConnections();
 	QList<rpc::MasterBrokerConnection*> masterBrokerConnections() const;

--- a/libshvbroker/src/brokeraclnode.cpp
+++ b/libshvbroker/src/brokeraclnode.cpp
@@ -62,6 +62,9 @@ static const std::vector<cp::MetaMethod> meta_methods_acl_subnode {
 	{M_VALUE, cp::MetaMethod::Flag::None, {}, "RpcValue", shv::chainpack::AccessLevel::Read},
 };
 
+//========================================================
+// EtcAclRootNode
+//========================================================
 static const std::string M_SAVE_TO_CONFIG_FILES = "saveToConfigFiles";
 static const std::vector<cp::MetaMethod> meta_methods_acl_root {
 	shv::chainpack::methods::DIR,
@@ -69,9 +72,6 @@ static const std::vector<cp::MetaMethod> meta_methods_acl_root {
 	{M_SAVE_TO_CONFIG_FILES, cp::MetaMethod::Flag::None, {}, "RpcValue", shv::chainpack::AccessLevel::Config},
 };
 
-//========================================================
-// EtcAclRootNode
-//========================================================
 EtcAclRootNode::EtcAclRootNode(shv::iotqt::node::ShvNode *parent)
 	: Super("acl", &meta_methods_acl_root, parent)
 {

--- a/libshvbroker/src/brokerappnode.cpp
+++ b/libshvbroker/src/brokerappnode.cpp
@@ -75,7 +75,7 @@ static const auto M_BROKER_ID = "brokerId";
 static const auto M_MASTER_BROKER_ID = "masterBrokerId";
 
 BrokerAppNode::BrokerAppNode(shv::iotqt::node::ShvNode *parent)
-	: Super("", &m_metaMethods, parent)
+	: Super("app", &m_metaMethods, parent)
 	, m_metaMethods {
 		shv::chainpack::methods::DIR,
 		shv::chainpack::methods::LS,

--- a/libshvbroker/src/dotbrokernode.cpp
+++ b/libshvbroker/src/dotbrokernode.cpp
@@ -1,0 +1,102 @@
+#include "dotbrokernode.h"
+
+#include "brokerappnode.h"
+#include "rpc/clientconnectiononbroker.h"
+
+#include <shv/broker/brokerapp.h>
+
+using namespace shv::chainpack;
+
+namespace shv::broker {
+
+class ClientsNode : public shv::iotqt::node::MethodsTableNode
+{
+	using Super = shv::iotqt::node::MethodsTableNode;
+public:
+	ClientsNode(shv::iotqt::node::ShvNode *parent = nullptr)
+		: Super("clients", &m_metaMethods, parent)
+		, m_metaMethods {
+			shv::chainpack::methods::DIR,
+			shv::chainpack::methods::LS,
+		}
+	{ }
+
+	StringList childNames(const StringViewList &shv_path) override
+	{
+		auto sl = Super::childNames(shv_path);
+		if(shv_path.empty()) {
+			std::vector<int> ids;
+			ids.reserve(sl.size());
+			for(const auto &s : sl)
+				ids.push_back(std::stoi(s));
+			std::sort(ids.begin(), ids.end());
+			for (size_t i = 0; i < ids.size(); ++i)
+				sl[i] = std::to_string(ids[i]);
+		}
+		return sl;
+	}
+private:
+	std::vector<MetaMethod> m_metaMethods;
+};
+
+namespace {
+const auto METH_MOUNTS = "mounts";
+const auto METH_MOUNTED_CLIENT_INFO = "mountedClientInfo";
+}
+
+DotBrokerNode::DotBrokerNode(ShvNode *parent)
+	: Super("", &m_metaMethods, parent)
+	, m_metaMethods {
+		shv::chainpack::methods::DIR,
+		shv::chainpack::methods::LS,
+		{METH_MOUNTS, shv::chainpack::MetaMethod::Flag::None, "n", "[s]", shv::chainpack::AccessLevel::Admin, {}},
+		{METH_MOUNTED_CLIENT_INFO, shv::chainpack::MetaMethod::Flag::None, "s", "{i:clientId,s|n:userName,s|n:mountPoint,{i|n}:subscriptions}|n", shv::chainpack::AccessLevel::Admin, {}},
+	}
+{
+	new BrokerAppNode(this);
+	new CurrentClientShvNode(this);
+	new ClientsNode(this);
+
+}
+
+chainpack::RpcValue DotBrokerNode::callMethod(const StringViewList &shv_path, const std::string &method, const chainpack::RpcValue &params, const chainpack::RpcValue &user_id)
+{
+	if (shv_path.empty()) {
+		if (method == METH_MOUNTS) {
+			auto *app = BrokerApp::instance();
+			StringList lst;
+			for(int id : app->clientConnectionIds()) {
+				auto *conn = app->clientConnectionById(id);
+				const auto mp = conn->mountPoint();
+				if(!mp.empty())
+					lst.push_back(mp);
+			}
+			std::sort(lst.begin(), lst.end());
+			return lst;
+		}
+		if (method == METH_MOUNTED_CLIENT_INFO) {
+			auto mount_point = params.asString();
+			auto *app = BrokerApp::instance();
+			for (auto id : app->clientConnectionIds()) {
+				auto *client = app->clientConnectionById(id);
+				if (client->mountPoint() == mount_point) {
+					chainpack::RpcValue::Map subscriptions;
+					for (size_t ix = 0; ix < client->subscriptionCount(); ++ix) {
+						const auto &subs = client->subscriptionAt(ix);
+						subscriptions[subs.toString()];
+					}
+					return chainpack::RpcValue::Map{
+						{"clientId", id},
+						{"userName", client->userName()},
+						{"mountPoint", mount_point},
+						{"subscriptions", subscriptions},
+					};
+				}
+			}
+			return chainpack::RpcValue(nullptr);
+		}
+	}
+	return Super::callMethod(shv_path, method, params, user_id);
+}
+
+}

--- a/libshvbroker/src/dotbrokernode.h
+++ b/libshvbroker/src/dotbrokernode.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <shv/iotqt/node/shvnode.h>
+#include <shv/chainpack/rpcvalue.h>
+
+#include <QObject>
+
+namespace shv::broker {
+
+class DotBrokerNode : public shv::iotqt::node::MethodsTableNode
+{
+	Q_OBJECT
+
+	using Super = shv::iotqt::node::MethodsTableNode;
+public:
+	DotBrokerNode(shv::iotqt::node::ShvNode *parent = nullptr);
+
+	shv::chainpack::RpcValue callMethod(const StringViewList &shv_path, const std::string &method, const shv::chainpack::RpcValue &params, const shv::chainpack::RpcValue &user_id) override;
+private:
+	std::vector<shv::chainpack::MetaMethod> m_metaMethods;
+};
+
+}
+


### PR DESCRIPTION
Step towards compatibility with SHV3.
This also removes currently not working .broker/mounts node.