### PR TITLE
Remove unneeded define alias

### DIFF
--- a/libshvvisu/include/shv/visu/logview/dlgloginspector.h
+++ b/libshvvisu/include/shv/visu/logview/dlgloginspector.h
@@ -6,7 +6,7 @@
 
 #include <QDialog>
 
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 #include <QTimeZone>
 #endif
 
@@ -48,7 +48,7 @@ private:
 	void saveData(const std::string &data, const QString& ext);
 	std::string loadData(const QString &ext);
 
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 	void setTimeZone(const QTimeZone &tz);
 #endif
 
@@ -57,7 +57,7 @@ private:
 private:
 	Ui::DlgLogInspector *ui;
 
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 	QTimeZone m_timeZone;
 #endif
 

--- a/libshvvisu/include/shv/visu/logview/logmodel.h
+++ b/libshvvisu/include/shv/visu/logview/logmodel.h
@@ -6,7 +6,7 @@
 #include <shv/core/utils/shvmemoryjournal.h>
 
 #include <QAbstractTableModel>
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 #include <QTimeZone>
 #endif
 
@@ -21,7 +21,7 @@ public:
 	enum {ColDateTime = 0, ColPath, ColValue, ColShortTime, ColDomain, ColValueFlags, ColUserId,  ColCnt};
 public:
 	LogModel(QObject *parent = nullptr);
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 	void setTimeZone(const QTimeZone &tz);
 #endif
 
@@ -34,7 +34,7 @@ public:
 	QVariant data(const QModelIndex &index, int role) const override;
 protected:
 	shv::chainpack::RpcValue m_log;
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 	QTimeZone m_timeZone;
 #endif
 };

--- a/libshvvisu/include/shv/visu/shvvisuglobal.h
+++ b/libshvvisu/include/shv/visu/shvvisuglobal.h
@@ -9,5 +9,3 @@
 #else
 #  define SHVVISU_DECL_EXPORT Q_DECL_IMPORT
 #endif
-
-#define SHVVISU_HAS_TIMEZONE QT_FEATURE_timezone == 1

--- a/libshvvisu/include/shv/visu/timeline/graph.h
+++ b/libshvvisu/include/shv/visu/timeline/graph.h
@@ -19,7 +19,7 @@
 #include <QFont>
 #include <QPixmap>
 #include <QRect>
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 #include <QTimeZone>
 #endif
 
@@ -109,7 +109,7 @@ public:
 	void setModel(GraphModel *model);
 	GraphModel *model() const;
 
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 	void setTimeZone(const QTimeZone &tz);
 	QTimeZone timeZone() const;
 #endif
@@ -299,7 +299,7 @@ protected:
 protected:
 	GraphModel *m_model = nullptr;
 
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 	QTimeZone m_timeZone;
 #endif
 

--- a/libshvvisu/include/shv/visu/timeline/graphwidget.h
+++ b/libshvvisu/include/shv/visu/timeline/graphwidget.h
@@ -26,7 +26,7 @@ public:
 	Graph *graph();
 	const Graph *graph() const;
 
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 	void setTimeZone(const QTimeZone &tz);
 #endif
 

--- a/libshvvisu/include/shv/visu/widgets/timezonecombobox.h
+++ b/libshvvisu/include/shv/visu/widgets/timezonecombobox.h
@@ -14,7 +14,7 @@ class SHVVISU_DECL_EXPORT TimeZoneComboBox : public QComboBox
 public:
 	TimeZoneComboBox(QWidget *parent = nullptr);
 
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 	QTimeZone currentTimeZone() const;
 protected:
 	void keyPressEvent(QKeyEvent *event) override;

--- a/libshvvisu/src/logview/dlgloginspector.cpp
+++ b/libshvvisu/src/logview/dlgloginspector.cpp
@@ -28,7 +28,7 @@
 #include <QSettings>
 #include <QSortFilterProxyModel>
 #include <QStandardItemModel>
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 #include <QTimeZone>
 #endif
 
@@ -230,7 +230,7 @@ DlgLogInspector::DlgLogInspector(const QString &shv_path, QWidget *parent) :
 
 	ui->wDataViewFilterSelector->init(ui->edShvPath->text(), m_graph);
 
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 	connect(ui->cbxTimeZone, &QComboBox::currentTextChanged, this, [this](const QString &) {
 		auto tz = ui->cbxTimeZone->currentTimeZone();
 		setTimeZone(tz);
@@ -296,7 +296,7 @@ void DlgLogInspector::setShvPath(const QString &s)
 shv::chainpack::RpcValue DlgLogInspector::getLogParams()
 {
 	shv::core::utils::ShvGetLogParams params;
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 	auto get_dt = [this](QDateTimeEdit *ed) {
 #else
 	auto get_dt = [](QDateTimeEdit *ed) {
@@ -304,7 +304,7 @@ shv::chainpack::RpcValue DlgLogInspector::getLogParams()
 		QDateTime dt = ed->dateTime();
 		if(dt == ed->minimumDateTime())
 			return  cp::RpcValue();
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 		dt = QDateTime(dt.date(), dt.time(), m_timeZone);
 #else
 		dt = QDateTime(dt.date(), dt.time());
@@ -479,7 +479,7 @@ void DlgLogInspector::saveData(const std::string &data_to_be_saved, const QStrin
 	}
 }
 
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 void DlgLogInspector::setTimeZone(const QTimeZone &tz)
 {
 	shvDebug() << "Setting timezone to:" << tz.id();

--- a/libshvvisu/src/logview/logmodel.cpp
+++ b/libshvvisu/src/logview/logmodel.cpp
@@ -18,7 +18,7 @@ LogModel::LogModel(QObject *parent)
 
 }
 
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 void LogModel::setTimeZone(const QTimeZone &tz)
 {
 	m_timeZone = tz;
@@ -82,7 +82,7 @@ QVariant LogModel::data(const QModelIndex &index, int role) const
 				if(msec == 0)
 					return QVariant();
 				QDateTime dt = QDateTime::fromMSecsSinceEpoch(msec);
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 				dt = dt.toTimeZone(m_timeZone);
 #endif
 				return dt.toString(Qt::ISODateWithMs);

--- a/libshvvisu/src/timeline/channelprobe.cpp
+++ b/libshvvisu/src/timeline/channelprobe.cpp
@@ -34,7 +34,7 @@ QString ChannelProbe::currentTimeIsoFormat() const
 {
 	if (m_graph->model()->xAxisType() == GraphModel::XAxisType::Timeline) {
 		QDateTime dt = QDateTime::fromMSecsSinceEpoch(m_currentTime);
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 		if (m_graph->timeZone().isValid())
 			dt = dt.toTimeZone(m_graph->timeZone());
 #endif

--- a/libshvvisu/src/timeline/graph.cpp
+++ b/libshvvisu/src/timeline/graph.cpp
@@ -62,7 +62,7 @@ bool Graph::DataRect::isValid() const
 Graph::Graph(QObject *parent)
 	: QObject(parent)
 {
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 	m_timeZone = QTimeZone::utc();
 #endif
 }
@@ -94,7 +94,7 @@ void Graph::setSettingsUserName(const QString &user)
 	m_settingsUserName = user;
 }
 
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 void Graph::setTimeZone(const QTimeZone &tz)
 {
 	shvDebug() << "set timezone:" << tz.id();
@@ -1000,7 +1000,7 @@ QVariantMap Graph::sampleValues(qsizetype channel_ix, const shv::visu::timeline:
 	shvDebug() << channel_info.shvPath << channel_info.typeDescr.toRpcValue().toCpon();
 
 	QDateTime dt = QDateTime::fromMSecsSinceEpoch(s.time);
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 	dt = dt.toTimeZone(timeZone());
 #endif
 	ret[KEY_SAMPLE_TIME] = dt;
@@ -1713,13 +1713,13 @@ void Graph::drawXAxis(QPainter *painter)
 		QPoint p1{x, m_layout.xAxisRect.top()};
 		QPoint p2{p1.x(), p1.y() + 2*tick_len};
 		painter->drawLine(p1, p2);
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 		auto date_time_tz = [this](timemsec_t epoch_msec) {
 #else
 		auto date_time_tz = [](timemsec_t epoch_msec) {
 #endif
 			QDateTime dt = QDateTime::fromMSecsSinceEpoch(epoch_msec);
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 			dt = dt.toTimeZone(m_timeZone);
 #endif
 			return dt;
@@ -2752,7 +2752,7 @@ QString Graph::timeToStringTZ(timemsec_t time) const
 {
 	if (m_model->xAxisType() == GraphModel::XAxisType::Timeline) {
 		QDateTime dt = QDateTime::fromMSecsSinceEpoch(time);
-	#if SHVVISU_HAS_TIMEZONE
+	#if QT_CONFIG(timezone)
 		if(m_timeZone.isValid())
 			dt = dt.toTimeZone(m_timeZone);
 	#endif

--- a/libshvvisu/src/timeline/graphwidget.cpp
+++ b/libshvvisu/src/timeline/graphwidget.cpp
@@ -75,7 +75,7 @@ const Graph *GraphWidget::graph() const
 	return m_graph;
 }
 
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 void GraphWidget::setTimeZone(const QTimeZone &tz)
 {
 	graph()->setTimeZone(tz);

--- a/libshvvisu/src/widgets/timezonecombobox.cpp
+++ b/libshvvisu/src/widgets/timezonecombobox.cpp
@@ -2,7 +2,7 @@
 
 #include <QKeyEvent>
 #include <QLineEdit>
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 #include <QTimeZone>
 #endif
 
@@ -11,7 +11,7 @@ namespace shv::visu::widgets {
 TimeZoneComboBox::TimeZoneComboBox(QWidget *parent)
 	: Super(parent)
 {
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 	setEditable(true);
 	for(const auto &tzn : QTimeZone::availableTimeZoneIds())
 		addItem(tzn);
@@ -19,7 +19,7 @@ TimeZoneComboBox::TimeZoneComboBox(QWidget *parent)
 #endif
 }
 
-#if SHVVISU_HAS_TIMEZONE
+#if QT_CONFIG(timezone)
 QTimeZone TimeZoneComboBox::currentTimeZone() const
 {
 	if(currentIndex() < 0)


### PR DESCRIPTION
There is no need to rename this alias, let's just use the Qt definition. This macro was also used by some downstream applications, which created errors when removing shvvisuglobal from the include chain (e.g. by removing dependency on shvvisu).