### PR TITLE
Fix build of clientconnection.cpp with older compilers

### DIFF
--- a/libshviotqt/src/rpc/clientconnection.cpp
+++ b/libshviotqt/src/rpc/clientconnection.cpp
@@ -44,7 +44,7 @@
 #include <regex>
 
 namespace {
-constexpr std::string REQUEST_SESSION_KEY = "session";
+constexpr auto REQUEST_SESSION_KEY = "session";
 }
 
 namespace cp = shv::chainpack;


### PR DESCRIPTION
```
/home/runner/work/quickevent/quickevent/3rdparty/libshv/libshviotqt/src/rpc/clientconnection.cpp:47:23: error: the type ‘const string’ {aka ‘const std::__cxx11::basic_string<char>’} of ‘constexpr’ variable ‘{anonymous}::REQUEST_SESSION_KEY’ is not literal
   47 | constexpr std::string REQUEST_SESSION_KEY = "session";
      |                       ^~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/11/string:55,
                 from /usr/include/c++/11/bits/locale_classes.h:40,
                 from /usr/include/c++/11/bits/ios_base.h:41,
                 from /usr/include/c++/11/ios:42,
                 from /home/runner/work/quickevent/quickevent/3rdparty/libshv/libshvchainpack/include/shv/chainpack/rpcvalue.h:8,
                 from /home/runner/work/quickevent/quickevent/3rdparty/libshv/libshvchainpack/include/shv/chainpack/rpcmessage.h:4,
                 from /home/runner/work/quickevent/quickevent/3rdparty/libshv/libshvchainpack/include/shv/chainpack/irpcconnection.h:3,
                 from /home/runner/work/quickevent/quickevent/3rdparty/libshv/libshviotqt/include/shv/iotqt/rpc/socketrpcconnection.h:5,
                 from /home/runner/work/quickevent/quickevent/3rdparty/libshv/libshviotqt/include/shv/iotqt/rpc/clientconnection.h:3,
                 from /home/runner/work/quickevent/quickevent/3rdparty/libshv/libshviotqt/src/rpc/clientconnection.cpp:1:
/usr/include/c++/11/bits/basic_string.h:85:11: note: ‘std::__cxx11::basic_string<char>’ is not literal because:
   85 |     class basic_string
      |           ^~~~~~~~~~~~
/usr/include/c++/11/bits/basic_string.h:85:11: note:   ‘std::__cxx11::basic_string<char>’ does not have ‘constexpr’ destructor
```